### PR TITLE
Fix a "no such file or directory" in src2bin.py

### DIFF
--- a/src2bin.py
+++ b/src2bin.py
@@ -21,6 +21,8 @@ def compress():
             fileExtension = args.ext
         archname = '%s.%s' % (fileName, fileExtension)
         archpath = os.path.join('bin', archname)
+        if not os.path.isdir('bin'):
+            os.mkdir('bin')
         with zipfile.ZipFile(archpath, "w") as archive:
             n = 0
             for dirname, dirnames, filenames in os.walk(os.path.join('src', rootname)):


### PR DESCRIPTION
After downloaded and unzipped leeno-master.zip, there wasn't any "bin" directory in leeno-master, thus the src2bin.py failed with the error:
IOError: [Errno 2] No such file or directory: 'bin/Ultimus.oxt'
Check if the directory "bin" exists, if not, creates it.

Tested locally, the file "Ultimus.oxt" is correctly created inside the "bin" dir.
